### PR TITLE
Fix stale surface tracking on load

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/IONbtReader.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/IONbtReader.java
@@ -374,10 +374,15 @@ public class IONbtReader {
         }
 
         IHeightMap heightMap = ((IColumn) cube.getColumn()).getOpacityIndex();
+        int cubeMaxY = Coords.cubeToMaxBlock(cube.getY());
 
         for (int localX = 0; localX < Cube.SIZE; localX++) {
             for (int localZ = 0; localZ < Cube.SIZE; localZ++) {
                 int columnTop = heightMap.getTopBlockY(localX, localZ);
+                if (columnTop >= cubeMaxY) {
+                    continue;
+                }
+
                 for (int localY = Cube.SIZE - 1; localY >= 0; localY--) {
                     Block block = storage.getBlockByExtId(localX, localY, localZ);
                     if (block != null && block.getLightOpacity() > 0) {

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/IONbtReader.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/IONbtReader.java
@@ -206,6 +206,7 @@ public class IONbtReader {
         readTileEntities(level, world, cube);
         readScheduledBlockTicks(level, world);
         readLightingInfo(cube, level, world);
+        validateSurfaceTracking(cube);
 
         cube.getColumn()
             .preCacheCube(cube);
@@ -360,6 +361,35 @@ public class IONbtReader {
         }
         NBTTagCompound lightingInfo = nbt.getCompoundTag("LightingInfo");
         lightingManager.readFromNbt(cube, lightingInfo);
+    }
+
+    private static void validateSurfaceTracking(Cube cube) {
+        if (!cube.isSurfaceTracked()) {
+            return;
+        }
+
+        ExtendedBlockStorage storage = cube.getStorage();
+        if (storage == null || storage.isEmpty()) {
+            return;
+        }
+
+        IHeightMap heightMap = ((IColumn) cube.getColumn()).getOpacityIndex();
+
+        for (int localX = 0; localX < Cube.SIZE; localX++) {
+            for (int localZ = 0; localZ < Cube.SIZE; localZ++) {
+                int columnTop = heightMap.getTopBlockY(localX, localZ);
+                for (int localY = Cube.SIZE - 1; localY >= 0; localY--) {
+                    Block block = storage.getBlockByExtId(localX, localY, localZ);
+                    if (block != null && block.getLightOpacity() > 0) {
+                        if (columnTop < Coords.localToBlock(cube.getY(), localY)) {
+                            cube.setSurfaceTracked(false);
+                            return;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     private static void readBiomes(Cube cube, NBTTagCompound nbt) {// biomes


### PR DESCRIPTION
When a cube is loaded from disk it can say that its surface is already tracked, but the column height map can still be lower than blocks actually present in that cube. If that happens, vanilla height queries like Chunk#getHeightValue can return bad values, which causes JourneyMap to sometimes show bugged tiles for chunks that were already generated and loaded again.

This checks loaded tracked cubes against the column opacity index. If the cube contains an opaque block above the column's stored top height, it marks the cube surface as untracked so the existing surface tracking code rebuilds it.

This is how JourneyMap looked when loading into a world before the fix:

<img width="1058" height="947" alt="loading-before-fix" src="https://github.com/user-attachments/assets/b3eccb9a-c067-49a7-88e9-614e5d7826c8" />

Tested in GTNH 2.9.0-beta-1