### PR TITLE
Fix FMP memory leak by mirroring vanilla behaviour for chunk saving

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderServer.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderServer.java
@@ -630,12 +630,9 @@ public class CubeLoaderServer implements ICubeLoader {
         }
 
         public void onColumnUnloaded() {
-            if (column.isModified) {
-                cubeIO.saveColumn(pos, column);
-            }
-
             column.onChunkUnload();
             callback.onColumnUnloaded(column);
+            cubeIO.saveColumn(pos, column);
         }
     }
 

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderServer.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderServer.java
@@ -632,7 +632,13 @@ public class CubeLoaderServer implements ICubeLoader {
         public void onColumnUnloaded() {
             column.onChunkUnload();
             callback.onColumnUnloaded(column);
-            cubeIO.saveColumn(pos, column);
+            column.onChunkUnload();
+
+            try {
+                cubeIO.saveColumn(pos, column);
+            } finally {
+                callback.onColumnUnloaded(column);
+            }
         }
     }
 

--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderServer.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/CubeLoaderServer.java
@@ -631,8 +631,6 @@ public class CubeLoaderServer implements ICubeLoader {
 
         public void onColumnUnloaded() {
             column.onChunkUnload();
-            callback.onColumnUnloaded(column);
-            column.onChunkUnload();
 
             try {
                 cubeIO.saveColumn(pos, column);


### PR DESCRIPTION
## Summary
There's currently a leak in FMP (CodeChickenCore, to be specific) that causes it to create a ChunkExtension object for each loaded chunk, but never clean them up. It's caused by CC saving, then unloading chunks. Vanilla unloads, then saves chunks. FMP expects chunks to be unloaded when they get saved, which causes CodeChickenCore to pop the ChunkExtension and write it to the chunk's NBT.

This is the code that's currently broken:
https://github.com/GTNewHorizons/CodeChickenCore/blob/60d44f3c7bf69a757b3f5e99d17f347d5b82629f/src/main/java/codechicken/lib/world/WorldExtensionManager.java#L42

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
