### PR TITLE
Fix ae2 chunk resend issue68

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/Mixins.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/Mixins.java
@@ -309,6 +309,11 @@ public enum Mixins implements IMixins {
             .addCommonMixins("mod.MixinBlockPosUtil")
             .setPhase(Phase.LATE)
             .addRequiredMod(Mods.ChunkAPI)
+            .setApplyIf(() -> true)),
+    MIXIN_AE2_PLATFORM_SEND_CHUNK(
+        new MixinBuilder("Route AE2 chunk section resends through the cubic synchronization protocol")
+            .addCommonMixins("mod.MixinAE2Platform")
+            .setPhase(Phase.EARLY)
             .setApplyIf(() -> true))
     //
     ;

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/mod/MixinAE2Platform.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/mod/MixinAE2Platform.java
@@ -1,6 +1,5 @@
 package com.cardinalstar.cubicchunks.mixin.early.mod;
 
-import net.minecraft.server.management.PlayerManager;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.chunk.Chunk;
 
@@ -22,11 +21,7 @@ public abstract class MixinAE2Platform {
             return;
         }
 
-        PlayerManager playerManager = world.getPlayerManager();
-
-        if (playerManager instanceof CubicPlayerManager cubicPlayerManager) {
-            cubicPlayerManager.resendChunkSections(chunk, sectionMask);
-            ci.cancel();
-        }
+        ((CubicPlayerManager) world.getPlayerManager()).resendChunkSections(chunk, sectionMask);
+        ci.cancel();
     }
 }

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/mod/MixinAE2Platform.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/mod/MixinAE2Platform.java
@@ -1,0 +1,32 @@
+package com.cardinalstar.cubicchunks.mixin.early.mod;
+
+import net.minecraft.server.management.PlayerManager;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.chunk.Chunk;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.cardinalstar.cubicchunks.server.CubicPlayerManager;
+
+@Pseudo
+@Mixin(targets = "appeng.util.Platform", remap = false)
+public abstract class MixinAE2Platform {
+
+    @Inject(method = "sendChunk", at = @At("HEAD"), cancellable = true)
+    private static void resendCubicChunkSections(Chunk chunk, int sectionMask, CallbackInfo ci) {
+        if (!(chunk.worldObj instanceof WorldServer world)) {
+            return;
+        }
+
+        PlayerManager playerManager = world.getPlayerManager();
+
+        if (playerManager instanceof CubicPlayerManager cubicPlayerManager) {
+            cubicPlayerManager.resendChunkSections(chunk, sectionMask);
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/com/cardinalstar/cubicchunks/server/CubicPlayerManager.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/CubicPlayerManager.java
@@ -246,6 +246,21 @@ public class CubicPlayerManager extends PlayerManager implements CubeLoaderCallb
         }
     }
 
+    public void resendChunkSections(Chunk column, int sectionMask) {
+        while (sectionMask != 0) {
+            int cubeY = Integer.numberOfTrailingZeros(sectionMask);
+            sectionMask &= ~(1 << cubeY);
+
+            Cube cube = provider.getLoadedCube(column.xPosition, cubeY, column.zPosition);
+
+            if (cube != null) {
+                for (var player : players.getPlayerArray()) {
+                    player.sync.resendCube(cube);
+                }
+            }
+        }
+    }
+
     // Note these arguments are in global block coordinates
 
     public void onSurfaceTracked(Cube cube) {

--- a/src/main/java/com/cardinalstar/cubicchunks/server/CubicPlayerManager.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/CubicPlayerManager.java
@@ -247,9 +247,8 @@ public class CubicPlayerManager extends PlayerManager implements CubeLoaderCallb
     }
 
     public void resendChunkSections(Chunk column, int sectionMask) {
-        while (sectionMask != 0) {
-            int cubeY = Integer.numberOfTrailingZeros(sectionMask);
-            sectionMask &= ~(1 << cubeY);
+        for (int cubeY = 0; cubeY < 16; cubeY++) {
+            if ((sectionMask & (1 << cubeY)) == 0) continue;
 
             Cube cube = provider.getLoadedCube(column.xPosition, cubeY, column.zPosition);
 

--- a/src/main/java/com/cardinalstar/cubicchunks/server/WorldSyncStateMachine.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/WorldSyncStateMachine.java
@@ -107,16 +107,7 @@ public class WorldSyncStateMachine {
                 columnData.syncedCubeCount++;
                 syncedCubes.add(pos);
 
-                PacketEncoderCube.createPacket(cube)
-                    .sendToPlayer(player.player);
-
-                cube.cubeTileEntityMap.forEach((tePos, te) -> {
-                    Packet desc = te.getDescriptionPacket();
-
-                    if (desc != null) {
-                        player.player.playerNetServerHandler.sendPacket(desc);
-                    }
-                });
+                sendCubeData(cube);
 
                 dirtyBlocks.remove(pos.getX(), pos.getY(), pos.getZ());
 
@@ -209,5 +200,26 @@ public class WorldSyncStateMachine {
     public void onBlockMarkedDirty(int x, int y, int z) {
         dirtyBlocks.computeIfAbsent(x >> 4, y >> 4, z >> 4, (x1, y1, z1) -> new ShortOpenHashSet())
             .add((short) AddressTools.getLocalAddress(x, y, z));
+    }
+
+    public void resendCube(Cube cube) {
+        CubePos pos = cube.getCoords();
+
+        if (syncedCubes.contains(pos) && player.isWatchingCube(pos.getX(), pos.getY(), pos.getZ())) {
+            sendCubeData(cube);
+        }
+    }
+
+    private void sendCubeData(Cube cube) {
+        PacketEncoderCube.createPacket(cube)
+            .sendToPlayer(player.player);
+
+        cube.cubeTileEntityMap.forEach((tePos, te) -> {
+            Packet desc = te.getDescriptionPacket();
+
+            if (desc != null) {
+                player.player.playerNetServerHandler.sendPacket(desc);
+            }
+        });
     }
 }


### PR DESCRIPTION
Fixes #68, AE2 uses sendToAllPlayersWatchingChunk and S21PacketChunkData to make bulk transmissions when generating Meteors instead of sending every block change individually
