### PR TITLE
Sync removal of final block in cube

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/MixinWorld_HeightLimit.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/MixinWorld_HeightLimit.java
@@ -545,9 +545,7 @@ public abstract class MixinWorld_HeightLimit implements ICubicWorld {
         @Local(argsOnly = true, ordinal = 1) int y, @Local(argsOnly = true, ordinal = 2) int z) {
         ICube cube = ((IColumn) column).getCube(Coords.blockToCube(y));
 
-        if (cube == null || cube.isEmpty()) return false;
-
-        return cube.isPopulated();
+        return cube != null && cube.isPopulated();
     }
 
     @Redirect(


### PR DESCRIPTION
Fixed issue where leafs decaying would not be updated in the client, this always effected the last leaf in the cube because any updates making a cube empty would not be synced
<img width="2518" height="1387" alt="image" src="https://github.com/user-attachments/assets/e0d5610e-7663-4f44-932c-81ecb7f1921a" />
