### PR TITLE
Fix issue75 population height

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/MixinChunk.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/MixinChunk.java
@@ -361,8 +361,8 @@ public abstract class MixinChunk implements IColumn, IColumnInternal {
     // ==============================================
 
     /**
-     * @author CardinalStar
-     * @reason Vanilla only checks the fixed storage array, which does not contain unloaded cubic surface sections.
+     * @author Jakfut
+     * @reason Vanilla only checks the fixed storage array, which cannot represent unloaded cubic surface sections.
      */
     @Overwrite
     public int getTopFilledSegment() {
@@ -390,7 +390,7 @@ public abstract class MixinChunk implements IColumn, IColumnInternal {
             }
         }
 
-        return highestCubeY == Integer.MIN_VALUE ? 0 : cubeToMinBlock(highestCubeY);
+        return highestCubeY == Integer.MIN_VALUE ? 0 : MathHelper.clamp_int(cubeToMinBlock(highestCubeY), 0, 256);
     }
 
     // ==============================================

--- a/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/MixinChunk.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/mixin/early/common/MixinChunk.java
@@ -22,6 +22,7 @@ package com.cardinalstar.cubicchunks.mixin.early.common;
 
 import static com.cardinalstar.cubicchunks.util.Coords.blockToCube;
 import static com.cardinalstar.cubicchunks.util.Coords.blockToLocal;
+import static com.cardinalstar.cubicchunks.util.Coords.cubeToMinBlock;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -353,6 +354,43 @@ public abstract class MixinChunk implements IColumn, IColumnInternal {
             this.getCube(cubeY)
                 .markDirty();
         }
+    }
+
+    // ==============================================
+    // getTopFilledSegment
+    // ==============================================
+
+    /**
+     * @author CardinalStar
+     * @reason Vanilla only checks the fixed storage array, which does not contain unloaded cubic surface sections.
+     */
+    @Overwrite
+    public int getTopFilledSegment() {
+        if (!isColumn) {
+            for (int cubeY = storageArrays.length - 1; cubeY >= 0; cubeY--) {
+                if (storageArrays[cubeY] != null) return storageArrays[cubeY].getYLocation();
+            }
+            return 0;
+        }
+
+        int highestCubeY = Integer.MIN_VALUE;
+        for (int localZ = 0; localZ < 16; localZ++) {
+            for (int localX = 0; localX < 16; localX++) {
+                int topBlockY = opacityIndex.getTopBlockY(localX, localZ);
+                if (topBlockY >= CubicChunks.MIN_SUPPORTED_BLOCK_Y) {
+                    highestCubeY = Math.max(highestCubeY, blockToCube(topBlockY));
+                }
+            }
+        }
+
+        for (Cube cube : cubeMap) {
+            ExtendedBlockStorage storage = cube.getStorage();
+            if (storage != null && !storage.isEmpty()) {
+                highestCubeY = Math.max(highestCubeY, cube.getY());
+            }
+        }
+
+        return highestCubeY == Integer.MIN_VALUE ? 0 : cubeToMinBlock(highestCubeY);
     }
 
     // ==============================================

--- a/src/main/java/com/cardinalstar/cubicchunks/worldgen/VanillaWorldGenerator.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/worldgen/VanillaWorldGenerator.java
@@ -377,6 +377,7 @@ public class VanillaWorldGenerator implements IWorldGenerator, IPreloadFailureDe
                         // columns in the
                         // negative directions (-x,z, x,-z, -x,-z).
 
+                        preparePopulationTerrain(loader, v.x(), v.z());
                         populateChunk(loader, v.x(), v.z());
                     }
 
@@ -426,6 +427,16 @@ public class VanillaWorldGenerator implements IWorldGenerator, IPreloadFailureDe
             return new Box(x, 0, z, x, 15, z);
         } else {
             return new Box(x, y, z, x, y, z);
+        }
+    }
+
+    private void preparePopulationTerrain(ICubeLoader loader, int columnX, int columnZ) {
+        for (int dx = 0; dx <= 1; dx++) {
+            for (int dz = 0; dz <= 1; dz++) {
+                for (int cubeY = 0; cubeY < 16; cubeY++) {
+                    loader.getCube(columnX + dx, cubeY, columnZ + dz, Requirement.GENERATE);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #75 by generating the required 2x2 terrain columns before legacy population and making getTopFilledSegment cube-aware.

Most of the misplaced houses seem to have been from the broken 2x2 terrain column generation, once I fixed that there was only one bugged house in 100 villages and with cube-aware getTopFilledSegment that should also be fixed, tho its hard to verify because it was so rare.

Tested with 0.1.13 alpha-pre, but should also work with 0.1.10 and without #97 