### PR TITLE
Fix stale vanilla heightmap after ChunkAPI load

### DIFF
--- a/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/IONbtReader.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/server/chunkio/IONbtReader.java
@@ -70,13 +70,13 @@ public class IONbtReader {
             return null;
         }
 
-        readOpacityIndex(level, column);
-
         if (!Mods.ChunkAPI.isModLoaded()) {
             readBiomes(level, column);
         } else {
             DataRegistryImpl.readChunkFromNBT(column, nbt);
         }
+
+        readOpacityIndex(level, column);
 
         column.isModified = false; // its exactly the same as on disk so its not modified
         ((IColumnInternal) column).setColumn(true);
@@ -114,10 +114,13 @@ public class IONbtReader {
     }
 
     private static void readOpacityIndex(NBTTagCompound nbt, Chunk chunk) {
-        if (!nbt.hasKey("HeightMap3D", NBT.TAG_BYTE_ARRAY)) return;
-
         IHeightMap hmap = ((IColumn) chunk).getOpacityIndex();
-        ((HeightMap3D) hmap).readData(new CCPacketBuffer(Unpooled.wrappedBuffer(nbt.getByteArray("HeightMap3D"))));
+        HeightMap3D heightMap3D = (HeightMap3D) hmap;
+        heightMap3D.setVanillaHeightMap(chunk.heightMap);
+
+        if (nbt.hasKey("HeightMap3D", NBT.TAG_BYTE_ARRAY)) {
+            heightMap3D.readData(new CCPacketBuffer(Unpooled.wrappedBuffer(nbt.getByteArray("HeightMap3D"))));
+        }
     }
 
     static CubeInitLevel getCubeInitLevel(NBTTagCompound nbt) {

--- a/src/main/java/com/cardinalstar/cubicchunks/world/heightmap/HeightMap3D.java
+++ b/src/main/java/com/cardinalstar/cubicchunks/world/heightmap/HeightMap3D.java
@@ -39,16 +39,21 @@ public class HeightMap3D implements IHeightMap {
     private final Array2D_16x16<YIntervalTree> heightmap = new Array2D_16x16<>(YIntervalTree[]::new);
 
     @Nonnull
-    private final VanillaHeightMap vanilla;
+    private VanillaHeightMap vanilla;
     private final int worldActualHeight;
 
     public HeightMap3D(int[] vanilla, int worldActualHeight) {
-        this.vanilla = new VanillaHeightMap(vanilla);
+        setVanillaHeightMap(vanilla);
         this.worldActualHeight = worldActualHeight;
 
         for (int i = 0; i < 256; i++) {
             this.heightmap.data()[i] = new YIntervalTree();
         }
+    }
+
+    /** Rebinds the vanilla view after an external chunk data manager replaces {@code Chunk.heightMap}. */
+    public void setVanillaHeightMap(int[] vanilla) {
+        this.vanilla = new VanillaHeightMap(vanilla);
     }
 
     @Override


### PR DESCRIPTION
Depends on #97 
Fixed stale skylight after modifying loaded columns with ChunkAPI, ChunkAPI replaces Chunk.heightMap while loading columns but HeightMap3D kept writing to the old array.